### PR TITLE
Update extconf.rb to reflect new mysql include paths

### DIFF
--- a/ext/swift/db/mysql/extconf.rb
+++ b/ext/swift/db/mysql/extconf.rb
@@ -9,6 +9,7 @@ inc_paths = %w(
   /usr/include/mysql
   /usr/local/include
   /usr/local/include/mysql
+  /usr/local/mysql/include
   /opt/local/include
   /opt/local/include/mysql
   /opt/local/include/mysql5


### PR DESCRIPTION
New installation of mysql on OSX Yosemite leaves headers in new location